### PR TITLE
fixed bug which prevents display of error messages

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -64,7 +64,7 @@ export default {
         const formDataKeys = Array.from(tempFormData.keys());
         for (const rawKey of formDataKeys) {
           let key = rawKey;
-          if (key.slice(-LOC_LEN) === `_${locale.key}`) key = key.slice(0, -LOC_LEN);
+          if (key.slice(-LOC_LEN) === `.${locale.key}`) key = key.slice(0, -LOC_LEN);
 
           const isArray = !!key.match(ARR_REGEX());
           if (isArray) {

--- a/resources/js/mixins/TranslatableField.js
+++ b/resources/js/mixins/TranslatableField.js
@@ -20,7 +20,7 @@ export default {
         (this.fields[locale.key] = {
           ...this.field,
           value: initialValues[locale.key] || '',
-          attribute: `${this.field.attribute}_${locale.key}`, // Append '_en' to avoid duplicate ID-s in DOM
+          attribute: `${this.field.attribute}.${locale.key}`, // Append '.en' to avoid duplicate ID-s in DOM
         })
     );
 


### PR DESCRIPTION
The error messages aren't being displayed because the error messages have a key of `attribute.locale`. But the field attribute name is in the format of `attribute_locale`

![Screen Shot 2020-02-24 at 2 44 35 PM](https://user-images.githubusercontent.com/10626045/75185853-cbe58300-5714-11ea-9c8e-6d02e86a357f.png)

This is the current status of the field when validation fails

![Screen Shot 2020-02-24 at 2 49 43 PM](https://user-images.githubusercontent.com/10626045/75185929-ef103280-5714-11ea-920f-e406b17e2ed9.png)

This PR fixes the issue by replacing `_` with `.`. After the fix the component looks like this

![Screen Shot 2020-02-24 at 2 52 17 PM](https://user-images.githubusercontent.com/10626045/75186147-60e87c00-5715-11ea-9098-d706b889f15d.png)

And the status of the field when validation fails 

![Screen Shot 2020-02-24 at 2 54 01 PM](https://user-images.githubusercontent.com/10626045/75186251-92614780-5715-11ea-980c-7a81fcce8a0a.png)

Please let me know if any other changes are neccessary.