### PR TITLE
Fix issue with packages that populates more than 1 attribute on the formData object

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -80,18 +80,27 @@ export default {
             field.fill(tempFormData);
 
             const formDataKeys = Array.from(tempFormData.keys());
+            const originalAttribute = this.field.translatable.original_attribute;
+
             for (const rawKey of formDataKeys) {
               const [key, value] = this.getKeyAndValue(rawKey, locale, tempFormData);
-              const isArray = this.isKeyAnArray(rawKey);
-              if (isArray) {
-                if (!data[locale.key]) data[locale.key] = [];
-                data[locale.key].push(value);
-              } else {
-                data[locale.key] = value;
+
+              if(key.endsWith(originalAttribute + `[${locale.key}]`)) {
+
+                const isArray = this.isKeyAnArray(rawKey);
+
+                if (isArray) {
+                  if (!data[locale.key]) data[locale.key] = [];
+                  data[locale.key].push(value);
+                } else {
+                  data[locale.key] = value;
+                }
+
               }
+
             }
           }
-          formData.append(this.field.translatable.original_attribute, JSON.stringify(data));
+          formData.append(originalAttribute, JSON.stringify(data));
           return;
         }
 


### PR DESCRIPTION
Hi, Me again

There is a suttle bug with a few packages that fill more than one attribute on their formData fill() method.. for example if My third party field does something like this:

```js
fill(formData) {
   formData.append(this.field.attribute, A)
   formData.append(this.field.attribute+'some_meta_data', B)
}
```

If make this field translatable the value that will be saved to the db will be `B` instead of `A` ... so with my change it ensure it only attempts to translate the `this.field.attribute` not everything else that may exist on the `formData` .

Please if you merge recompile the js I don't push it on purpose (do never accept minified data from strangers) :D