### PR TITLE
Use the locales from the Spatie's package config by default

### DIFF
--- a/config/nova-translatable.php
+++ b/config/nova-translatable.php
@@ -8,10 +8,12 @@ return [
      * The locales which the `translatable` wrapper will use by default.
      *
      * Can be a:
-     *  - Keyed array (['en' => 'English])
+     *  - Keyed array (['en' => 'English'])
      *  - Callable that returns a keyed array
      */
 
-    'locales' => ['en' => 'English'],
+    'locales' => function () {
+        return config('translatable.locales');
+    },
 
 ];


### PR DESCRIPTION
This way publishing the config is optional and I think for 99% the locales do not differ.