### PR TITLE
Move originalAttribute outside of the main for loop

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -74,13 +74,14 @@ export default {
           }
 
           const data = {};
+          const originalAttribute = this.field.translatable.original_attribute;
+          
           for (const locale of this.locales) {
             const tempFormData = new FormData();
             const field = this.fields[locale.key];
             field.fill(tempFormData);
 
-            const formDataKeys = Array.from(tempFormData.keys());
-            const originalAttribute = this.field.translatable.original_attribute;
+            const formDataKeys = Array.from(tempFormData.keys());            
 
             for (const rawKey of formDataKeys) {
               const [key, value] = this.getKeyAndValue(rawKey, locale, tempFormData);


### PR DESCRIPTION
Sorry I had edited the file from the github UI didn't realize I had placed the const on the wrong line... latest version breaks because the const was inside the for loop

![image](https://user-images.githubusercontent.com/2874967/80577598-bacd3100-8a39-11ea-9b2f-fef259ee3456.png)
