### PR TITLE
Fix issue with repeatable flexible field

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -5,6 +5,7 @@ namespace OptimistDigital\NovaTranslatable;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use Laravel\Nova\Fields\Field;
 
@@ -46,7 +47,7 @@ class FieldServiceProvider extends ServiceProvider
     public static function normalizeAttribute($attribute)
     {
         if (in_array(request()->method(), ['PUT', 'POST'])) {
-            if (substr($attribute, -2) === '.*') $attribute = substr($attribute, 0, -2);
+            if (Str::endsWith($attribute, '.*')) $attribute = Str::before($attribute, '.*');
         }
         return $attribute;
     }


### PR DESCRIPTION
Hi, 

I found an issue with this package and flexible content, somehow having multiple items when using flexible field cause a weird property to be saved alongside the original data... example:

![image](https://user-images.githubusercontent.com/2874967/80731096-0a485580-8b3d-11ea-8790-896319ab51e1.png)

What this PR does is instead of always removing the last `.*` from the attribute get whatever is before the first occurrence of `.*`

Currently this `header.*.*` returns `header.*`
With this PR `header.*.*` returns `header`