### PR TITLE
Hide locale tabs when there is only one locale

### DIFF
--- a/resources/js/components/LocaleTabs.vue
+++ b/resources/js/components/LocaleTabs.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="flex select-none" :class="wrapperClasses">
+  <div 
+    v-show="sortedLocales.length > 1"
+    class="flex select-none" 
+    :class="wrapperClasses"
+  >
     <div class="ml-auto">
       <a
         v-for="locale in sortedLocales"


### PR DESCRIPTION
Hi there. I'd like some fields to be prepared for multi-language, but hide the labels until there are more than one locale. Do you think something speaks against this change?