### PR TITLE
Fix error in PHP8 when working with arrays

### DIFF
--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -20,7 +20,7 @@ class TranslatableFieldMixin
                 $attribute = FieldServiceProvider::normalizeAttribute($attribute);
 
                 // Load value from either the model or from the given $value
-                if (isset($resource) && method_exists($resource, 'getTranslations')) {
+                if (isset($resource) && (is_object($resource) || is_string($resource)) && method_exists($resource, 'getTranslations')) {
                     // In case a model has the HasTranslations trait, but some fields are wrapped
                     // we must be prepared to get an Exception here
                     try {


### PR DESCRIPTION
PHP8 needs the first argument of `method_exists` to be an object or a string. An exception is thrown if it is an array. Therefore I added the `&& (is_object($resource) || is_string($resource))` to the ìf` statement.