### PR TITLE
Fix an error using flexible content and translatable

### DIFF
--- a/src/HandlesTranslatable.php
+++ b/src/HandlesTranslatable.php
@@ -27,7 +27,11 @@ trait HandlesTranslatable
 
             foreach ($attributeRules['translatable'] as $locale => $localeRules) {
                 $pos = strrpos($attribute, '.*');
-                $newRuleAttribute = substr_replace($attribute, '', $pos, strlen('.*'));
+                if($pos !== false) {
+                    $newRuleAttribute = substr_replace($attribute, '', $pos, strlen('.*'));
+                } else {
+                    $newRuleAttribute = $attribute;
+                }
                 $newRuleAtrribute = "{$newRuleAttribute}.{$locale}";
 
                 // We copy the locale rule into the rules array


### PR DESCRIPTION
If an attribute rule string not contains.* the formatRules function removes the first 2 letters of the rule.
We had this situation using whitecube/nova-flexible-content with translatable fields.